### PR TITLE
Switch to stdlib.h for malloc

### DIFF
--- a/cbits/hexml.c
+++ b/cbits/hexml.c
@@ -1,5 +1,5 @@
 #include "hexml.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 #include <ctype.h>


### PR DESCRIPTION
On OS X you get this when trying to build the package:

```
[1 of 1] Compiling Text.XML.Hexml   ( src/Text/XML/Hexml.hs, .stack-work/dist/x86_64-osx/Cabal-1.24.0.0/build/Text/XML/Hexml.o )

/Users/chris/Work/hexml/cbits/hexml.c:2:10: error:  fatal error: 'malloc.h' file not found
#include <malloc.h>
         ^
1 error generated.
`gcc' failed in phase `C Compiler'. (Exit code: 1)
```

Seeing as `malloc()` is in from stdlib.h anyway, I figure we can just use that instead.